### PR TITLE
Fix for the renaming of .css files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ After a steam update you have to redo the following install instructions.
 2. if you start Steam per autostart, check how to alter the autostart instructions in your distro and add the start option `-noverifyfiles`
 
 ### Other OS & Manual installation
-1. rename `libraryroot.css` in `Steam/steamui/css` to `steamlibraryroot.css`
-2. move both .css files (`custom.css` & `libraryroot.css`) from the skin folder into the css folder of steam 
+1. rename `5.css` in `Steam/steamui/css` to `steam5.css`
+2. move both .css files (`custom.css` & `5.css`) from the skin folder into the css folder of steam 
 3. if you start Steam per autostart, check how to alter the autostart instructions in your OS and add the start option `-noverifyfiles`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-Newest Version: 201217  
+Newest Version: 210116 
 All instructions can be found at [draculatheme.com/steam](https://draculatheme.com/steam).
 
 ## Team

--- a/css/5.css
+++ b/css/5.css
@@ -1,0 +1,2 @@
+@import 'steam5.css';
+@import 'custom.css';

--- a/css/libraryroot.css
+++ b/css/libraryroot.css
@@ -1,2 +1,0 @@
-@import 'steamlibraryroot.css';
-@import 'custom.css';

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 echo "Installing CSS…"
 
-originalfile="../../steamui/css/libraryroot.css"
-copiedfile="../../steamui/css/steamlibraryroot.css"
+originalfile="../../steamui/css/5.css"
+copiedfile="../../steamui/css/steam5.css"
 
 #stores word count of originalfile
 originalfilesize=$(wc -c $originalfile | awk '{print $1}')
 
 if [ $originalfilesize -gt 100 ] ; then
   #checks if libraryroot.css is from steam and copies it if true
-  echo "renaming libraryroot.css"
+  echo "renaming 5.css"
   mv $originalfile $copiedfile
 
 else 
   #if the original libraryroot.css is not there an error occured
   if [ ! -e $copiedfile ] ; then
-    echo "The original libraryroot.css file is missing"
+    echo "The original 5.css file is missing"
     echo "Pls remove all files in /steamui/css/ and start steam without flags to regain missing files"
   fi
 fi

--- a/resource/menus/steam.menu
+++ b/resource/menus/steam.menu
@@ -118,7 +118,7 @@
 			shellcmd="steam://openurl/https://github.com/dracula/steam/issues/new/choose"
 		}
     Version {
-      text="Theme Version 201217"
+      text="Theme Version 210116"
     }
 	}
 }


### PR DESCRIPTION
Steam decided to change the names of its .css files. Most importantly from `libraryroot.css` to `5.css` :facepalm:.

Renamed the css files, changed the install instructions and script and updated the version number.
