### PR TITLE
Add (x86) to Program Files on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ Use the terminal, Luke:
 1. download or clone this [repository](https://github.com/dracula/steam)
 2. extract (if downloaded compressed)
 3. move the extracted folder into your Steam skin folder (which is in the Steam base folder)  
-   default location: `C:\Program Files\Steam\Skins`
+   default location: `C:\Program Files (x86)\Steam\Skins`
 4. open Steam and go to `Steam -> Settings -> Preferences` and open the section `Interface`
 5. select the skin `Dracula` and restart Steam, done!
 


### PR DESCRIPTION
Steam is a 32 bit app so as such the app is installed in 'Program Files (x86)' not 'Program Files'