### PR TITLE
Update uinavigator.layout to fix missing header

### DIFF
--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -192,9 +192,6 @@
 		library_music_add_button {	ControlName=Button labelText=""	tooltiptext="#Music_Playlist_Details_Menu_Add" style="MusicAddButton" group=music_add_button visible=false }
 		library_music_player_icon { ControlName=URLLabel style="MusicPlayerIcon" tooltiptext="#music_tooltip_view_player" URLtext="steam://open/musicplayer" align=right group=music }
 
-		emailreminderbar { zpos=1 }
-		phonereminderbar { zpos=1 }
-
 		EVCert	{ controlname="Label" style="LabelEVCert" visible=false }
 		URLStatusImage	{ controlname="ImagePanel" style="URLStatusImage" group="urlsec" }
 	}
@@ -917,26 +914,23 @@
 		place { control=URLAnchor align=left y=54 height=28 width=max }
 		place { control=LibraryAnchor height=28 width=max start=URLAnchor dir=down }
 
- 	  	place { control=emailreminderbar margin-top=0 margin-left=6 margin-right=6 width=max height=48  start="LibraryAnchor" dir=down}
- 	  	place { control=phonereminderbar margin-top=0 margin-left=0 margin-right=6 width=max height=80  start=emailreminderbar dir=down}
-
-		// content pages - these are all pushed down by the email reminder bar (above) if it's visible
-		place { control=DownloadsPage 		width=max height=max margin-top=0 margin-left=2 margin-right=7 margin-bottom=20 start=phonereminderbar dir=down }
-		place { control=ScreenshotsPage 	width=max height=max margin-top=0 margin-left=2 margin-right=7 margin-bottom=20 start=phonereminderbar dir=down }
-		place { control=GamesPage_List		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=phonereminderbar dir=down }
-		place { control=GamesPage_Details 	width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=phonereminderbar dir=down }
-		place { control=GamesPage_Grid 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
-		place { control=WebPanel 			width=max height=max margin-top=0 margin-left=-7 margin-right=0 margin-bottom=21 start=phonereminderbar dir=down }
-		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=phonereminderbar dir=down }
+		// content pages 
+		place { control=DownloadsPage 		width=max height=max margin-top=0 margin-left=2 margin-right=7 margin-bottom=20 start=LibraryAnchor dir=down }
+		place { control=ScreenshotsPage 	width=max height=max margin-top=0 margin-left=2 margin-right=7 margin-bottom=20 start=LibraryAnchor dir=down }
+		place { control=GamesPage_List		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=LibraryAnchor dir=down }
+		place { control=GamesPage_Details 	width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=LibraryAnchor dir=down }
+		place { control=GamesPage_Grid 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=LibraryAnchor dir=down }
+		place { control=WebPanel 			width=max height=max margin-top=0 margin-left=-7 margin-right=0 margin-bottom=21 start=LibraryAnchor dir=down }
+		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=21 start=LibraryAnchor dir=down }
 		place { control=BroadcastPageMin		width=298 height=168 margin-top=0 margin-left=2 margin-right=30 margin-bottom=26 dir=down align=bottom-right }
 		place { control=BroadcastPageMinHoriz	width=298 height=168 margin-top=0 margin-left=2 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
-		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=-7 margin-right=0 margin-bottom=21 start=phonereminderbar dir=down }
-		place { control=NewLibraryPage		width=max height=max margin-top=0 margin-left=-6 margin-right=0 margin-bottom=21 start=phonereminderbar dir=down }
+		place { control=ConsolePage 		width=max height=max margin-top=0 margin-left=-7 margin-right=0 margin-bottom=21 start=LibraryAnchor dir=down }
+		place { control=NewLibraryPage		width=max height=max margin-top=0 margin-left=-6 margin-right=0 margin-bottom=21 start=LibraryAnchor dir=down }
 
-		place { control=MediaPage 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
-		place { control=ToolsPage 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
+		place { control=MediaPage 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=LibraryAnchor dir=down }
+		place { control=ToolsPage 		width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=LibraryAnchor dir=down }
 
-		place { control=MusicPage_Details width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=phonereminderbar dir=down }
+		place { control=MusicPage_Details width=max height=max margin-top=0 margin-left=2 margin-right=8 margin-bottom=20 start=LibraryAnchor dir=down }
 		place { control="library_music_player_icon" align=right y=57 height=16 width=16 margin-right=10 }
 	}
 


### PR DESCRIPTION
The default steam style seems to have removed the phonereminder and emailreminder panels, which the rest of the top bar was attached to, which is why it disappeared.

This should resolve #43 and #44.